### PR TITLE
Disable DNS forwarding

### DIFF
--- a/lib/yunohost/domain.py
+++ b/lib/yunohost/domain.py
@@ -160,6 +160,7 @@ def domain_add(auth, domain, dyndns=False):
             with open('%s/%s' % (dnsmasq_config_path, domain)) as f: pass
         except IOError as e:
             zone_lines = [
+             'resolv-file=',
              'address=/%s/%s' % (domain, ip),
              'txt-record=%s,"v=spf1 mx a -all"' % domain,
              'mx-host=%s,%s,5' % (domain, domain),


### PR DESCRIPTION
The current default configuration of dnsmasq allows anyone to do DNS recursive requests from the internet. Each server with this configuration is a candidate for participating to a DNS DDoS Amplification Attack.

Setting the resolv-file parameter is the only way I found to disable the forwarding to upstream servers. It could be added directly into dnsmasq.conf, instead of in each zone file as in my commit.