### PR TITLE
[fix] 2nd installation of apps with a hooks directory

### DIFF
--- a/lib/yunohost/app.py
+++ b/lib/yunohost/app.py
@@ -433,7 +433,7 @@ def app_install(auth, app, label=None, args=None):
         if 'hooks' in os.listdir(app_tmp_folder):
             for hook in os.listdir(app_tmp_folder +'/hooks'):
                 #TODO: do it with sed ?
-                if file[:1] != '.':
+                if hook[:1] != '.':
                     with open(app_tmp_folder +'/hooks/'+ hook, "r") as sources:
                         lines = sources.readlines()
                     with open(app_tmp_folder +'/hooks/'+ hook, "w") as sources:


### PR DESCRIPTION
Fix this problem during an installation:
yunohost app install /vagrant/apps/owncloud_ynh/
Extracting...
Done.
Traceback (most recent call last):
  File "/usr/bin/yunohost", line 160, in <module>
    print_json=PRINT_JSON, use_cache=USE_CACHE)
  File "/usr/lib/python2.7/dist-packages/moulinette/__init__.py", line 117, in cli
    moulinette.run(args, print_json)
  File "/usr/lib/python2.7/dist-packages/moulinette/interfaces/cli.py", line 202, in run
    ret = self.actionsmap.process(args, timeout=5)
  File "/usr/lib/python2.7/dist-packages/moulinette/actionsmap.py", line 462, in process
    return func(**arguments)
  File "/usr/lib/moulinette/yunohost/app.py", line 436, in app_install
    if file[:1] != '.':
UnboundLocalError: local variable 'file' referenced before assignment
