### PR TITLE
Get ipv6 locally (instead of from ip6.yunohost.org)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,6 +19,7 @@ Depends: moulinette (>= 2.2.1),
     python-apt,
     ca-certificates,
     python-dnspython,
-    netcat-openbsd
+    netcat-openbsd,
+    iproute2
 Description: YunoHost Python scripts
  Python functions to manage a YunoHost instance

--- a/lib/yunohost/dyndns.py
+++ b/lib/yunohost/dyndns.py
@@ -118,6 +118,7 @@ def dyndns_update(dyn_host="dynhost.yunohost.org", domain=None, key=None, ip=Non
 
     # IPv6
     if ipv6 is None:
+        new_ipv6 = None
         try:
             new_ipv6 = requests.get('http://ip6.yunohost.org').text
         except ConnectionError:


### PR DESCRIPTION
Following the discussion on #89 

I based my work ontop of [kload commit](https://github.com/YunoHost/moulinette-yunohost/commit/1ceb1259bc5f65cc94ce7447aa71117f9ad33dd2#diff-29d74bbf0c8633566b2ba97ef48d4b33R135) which includes some parts of #89.